### PR TITLE
[Issue 5] Allow sending long DMs

### DIFF
--- a/ttytter.pl
+++ b/ttytter.pl
@@ -3704,6 +3704,10 @@ sub common_split_post {
 	if ($quoted_status_url) {
 		$maxchars = $quotelinelength;
 	}
+	# Direct messages allegedly have no length restrictions now
+	if ( $dm_lead ne '' || $k =~ m/^[dD] / ) {
+		$maxchars = 2**53
+	}
 	my (@tweetstack) = &csplit($k, ($autosplit eq 'char' ||
 		$autosplit eq 'cut') ? 1 : 0, $maxchars);
 	my $m = shift(@tweetstack);


### PR DESCRIPTION
TTYtter tries to be helpful and let you know if you're sending a Tweet
that's too long, but DMs can be of allegedly unlimited lenght now, so we
should allow those to be sent.

Note that this does not change how long DMs are displayed. Long DMs are
displayed like so:

```
[DM dc1][FunnelFiasco/Sat Oct 31 12:14:39 +0000 2015] if all of the
raindrops were lemondrops and gumdrops oh what a rain that would be.
standing outside with my mouth
/messages/44104818-44104818
```
