### PR TITLE
Custom newline replacement characters

### DIFF
--- a/oysttyer.pl
+++ b/oysttyer.pl
@@ -114,7 +114,8 @@ BEGIN {
 		tokenkey tokensecret credurl keyf readlinerepaint
 		simplestart exception_is_maskable oldperl notco
 		notify_tool_path oauthurl oauthauthurl oauthaccurl oauthbase
-		signals_use_posix dostream eventbuf streamallreplies
+		signals_use_posix dostream eventbuf replacement_newline
+		replacement_carriagereturn streamallreplies
 	); %valid = (%opts_can_set, %opts_others);
 	$rc = (defined($rc) && length($rc)) ? $rc : "";
 	unless ($norc) {
@@ -156,6 +157,8 @@ BEGIN {
 	$supreturnto = $verbose + 0;
 	$postbreak_time = 0;
 	$postbreak_count = 0;
+	$replacement_newline ||= $seven ? ' [NL] ' : " \x{2424} ";
+	$replacement_carriagereturn ||= $seven ? ' [CR] ' : " \x{240D} ";
 
 	# our minimum official support is now 5.8.6.
 	if ($] < 5.008006 && !$oldperl) {
@@ -7638,8 +7641,8 @@ s/\\u([dD][890abAB][0-9a-fA-F]{2})\\u([dD][cdefCDEF][0-9a-fA-F]{2})/&deutf16($1,
 		$x =~ s/\&amp;/\&/g;
 	}
 	if ($newline) {
-		$x =~ s/\\n/\n/sg;
-		$x =~ s/\\r//sg;
+		$x =~ s/\\n/$replacement_newline/sg;
+		$x =~ s/\\r/$replacement_carriagereturn/sg;
 	}
 	return $x;
 }


### PR DESCRIPTION
Add two new options: `replacement_newline` and `replacement_carraigereturn` (defaulting to `' ␤ '` and `' ␍ '`). These allow me to see newlines in tweets without breaking the "flow" of my stream, and are of course configurable in `.ttytterrc`.

Fixes #20.

Does not interfere with the user writing `\n` to insert newlines AFAIK.
