### PR TITLE
UNIX agnostic shebang

### DIFF
--- a/oysttyer.pl
+++ b/oysttyer.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -s
+#!/usr/bin/env perl -s
 #########################################################################
 #
 # oysttyer v2.4 (c)2015-     oysttyer orginistion


### PR DESCRIPTION
Perl could be located in other directories, like /usr/local/bin/perl in FreeBSD

env allows to find the right one.

Reference: http://perlbrew.pl/Dealing-with-shebangs.html
