### PR TITLE
Add --http1.1 flag to curl

### DIFF
--- a/oysttyer.pl
+++ b/oysttyer.pl
@@ -903,7 +903,7 @@ if ($lynx) {
 	$simple_agent = "$baseagent -s -m 20";
 
 	@wend = ('-s', '-m', '20', '-A', "oysttyer/$oysttyer_VERSION",
-			'-H', 'Expect:');
+			'--http1.1', '-H', 'Expect:');
 	@wind = @wend;
 	$stringify_args = sub {
 		my $basecom = shift;


### PR DESCRIPTION
Without this flag, oysttyer was failing for me after upgrading to
curl 7.48.0.  This is because curl enables HTTP/2 by default on
HTTPS connections starting in 7.47.0.

Note that this change means that the minimum version of curl to
be supported is 7.33.0.  curl 7.33.0 was released in October 2013,
so hopefully 2 and a half years is enough for people to upgrade.
If not, it should be fairly easy to switch to -0 for using HTTP 1.0,
or to only use --http1.1 only if curl 7.33.0+ is detected.
