### PR TITLE
Add message when a tweet is quoted

### DIFF
--- a/oysttyer.pl
+++ b/oysttyer.pl
@@ -5797,6 +5797,10 @@ sub standardevent {
 			$g .= "$sou_sn revoked oAuth access to $tar_sn";
 		} elsif ($verb eq 'access_unrevoked') {
 			$g .= "$sou_sn restored oAuth access to $tar_sn";
+		} elsif ($verb eq 'quoted_tweet') {
+			my $rto = &destroy_all_tco($ref->{'target_object'});
+			my $txt = &descape($rto->{'text'});
+			$g .= "$sou_sn just quoted ${tar_sn}'s tweet: \"$txt\"";
 		} else {
 			# try to handle new types of events we don't
 			# recognize yet.


### PR DESCRIPTION
Simple addition to show a message when one's tweet is quoted by someone else. This could be merged in the first `if` that manages liked/unliked tweets, but it wouldn't help readability.

`$object->{'target_object'}->{'text'}` is the text that the person quoting the tweet has written, not the tweet being quoted.
